### PR TITLE
Remove annotation that is not needed any more

### DIFF
--- a/src/main/java/org/cobbzilla/util/daemon/AwaitResult.java
+++ b/src/main/java/org/cobbzilla/util/daemon/AwaitResult.java
@@ -2,12 +2,10 @@ package org.cobbzilla.util.daemon;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
-import lombok.ToString;
 
 import java.util.*;
 import java.util.concurrent.Future;
 
-@ToString
 public class AwaitResult<T> {
 
     @Getter private Map<Future, T> successes = new HashMap<>();


### PR DESCRIPTION
@cobbzilla please review (an easy one)

We had a warning from compiler as `toString` method is now defined within this class (we don't need the annotation any more).