### PR TITLE
Fix null dir test

### DIFF
--- a/src/main/java/org/cobbzilla/util/io/FileUtil.java
+++ b/src/main/java/org/cobbzilla/util/io/FileUtil.java
@@ -408,7 +408,10 @@ public class FileUtil {
     }
 
     public static boolean ensureDirExists(File dir) {
-        if (empty(dir)) return true;
+        if (dir == null) {
+            log.error("ensureDirExists: null as directory is not acceptable");
+            return false;
+        }
         if (!dir.exists() && !dir.mkdirs()) {
             log.error("ensureDirExists: error creating: " + abs(dir));
             return false;


### PR DESCRIPTION
Empty folder exists, so do not test here with `empty(dir)`.

@cobbzilla please review