### PR TITLE
Improve precision in generated BigDecimal-s

### DIFF
--- a/src/main/java/org/cobbzilla/util/daemon/ZillaRuntime.java
+++ b/src/main/java/org/cobbzilla/util/daemon/ZillaRuntime.java
@@ -148,10 +148,10 @@ public class ZillaRuntime {
     public static BigInteger bigint(byte val) { return new BigInteger(String.valueOf(val)); }
 
     public static BigDecimal big(String val) { return new BigDecimal(val); }
-    public static BigDecimal big(double val) { return new BigDecimal(val); }
-    public static BigDecimal big(float val) { return new BigDecimal(val); }
-    public static BigDecimal big(long val) { return new BigDecimal(val); }
-    public static BigDecimal big(int val) { return new BigDecimal(val); }
+    public static BigDecimal big(double val) { return new BigDecimal(String.valueOf(val)); }
+    public static BigDecimal big(float val) { return new BigDecimal(String.valueOf(val)); }
+    public static BigDecimal big(long val) { return new BigDecimal(String.valueOf(val)); }
+    public static BigDecimal big(int val) { return new BigDecimal(String.valueOf(val)); }
     public static BigDecimal big(byte val) { return new BigDecimal(String.valueOf(val)); }
 
     public static int percent(int value, double pct) { return percent(value, pct, RoundingMode.HALF_UP); }

--- a/src/main/java/org/cobbzilla/util/json/JsonUtil.java
+++ b/src/main/java/org/cobbzilla/util/json/JsonUtil.java
@@ -16,6 +16,7 @@ import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.cobbzilla.util.daemon.ZillaRuntime.big;
 import static org.cobbzilla.util.daemon.ZillaRuntime.die;
 import static org.cobbzilla.util.daemon.ZillaRuntime.empty;
 
@@ -375,7 +376,7 @@ public class JsonUtil {
         if (node instanceof IntNode) return new IntNode(Integer.parseInt(replacement));
         if (node instanceof LongNode) return new LongNode(Long.parseLong(replacement));
         if (node instanceof DoubleNode) return new DoubleNode(Double.parseDouble(replacement));
-        if (node instanceof DecimalNode) return new DecimalNode(new BigDecimal(replacement));
+        if (node instanceof DecimalNode) return new DecimalNode(big(replacement));
         if (node instanceof BigIntegerNode) return new BigIntegerNode(new BigInteger(replacement));
         return die("Path "+path+" refers to an unsupported ValueNode: "+ nodeClass);
     }

--- a/src/main/java/org/cobbzilla/util/reflect/ReflectionUtil.java
+++ b/src/main/java/org/cobbzilla/util/reflect/ReflectionUtil.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.cobbzilla.util.collection.ArrayUtil.arrayToString;
+import static org.cobbzilla.util.daemon.ZillaRuntime.big;
 import static org.cobbzilla.util.daemon.ZillaRuntime.die;
 import static org.cobbzilla.util.daemon.ZillaRuntime.empty;
 import static org.cobbzilla.util.string.StringUtil.uncapitalize;
@@ -93,10 +94,10 @@ public class ReflectionUtil {
 
     public static BigDecimal toBigDecimal(Object object) {
         if (object == null) return null;
-        if (object instanceof Double) return new BigDecimal((Double) object);
-        if (object instanceof Float) return new BigDecimal((Float) object);
-        if (object instanceof Number) return new BigDecimal(((Number) object).longValue());
-        if (object instanceof String) return new BigDecimal(object.toString());
+        if (object instanceof Double) return big((Double) object);
+        if (object instanceof Float) return big((Float) object);
+        if (object instanceof Number) return big(((Number) object).longValue());
+        if (object instanceof String) return big(object.toString());
         return null;
     }
 


### PR DESCRIPTION
Creating BigDecimal from double has precision loss: https://www.javaworld.com/article/2073176/caution--double-to-bigdecimal-in-java.html

Converting double to String first and then creating BigDecimal from that String fixes the problem.

@cobbzilla please review